### PR TITLE
update curator version,remove old zk 

### DIFF
--- a/99-integration/dubbo-samples-registry-test-curator-instance/case-versions.conf
+++ b/99-integration/dubbo-samples-registry-test-curator-instance/case-versions.conf
@@ -23,4 +23,4 @@
 dubbo.version=[ >= 3.2.0 ]
 spring.version=4.*, 5.*
 java.version= [ >= 8 ]
-curator.version= [ >= 4.0.0 ]
+curator.version= [ >= 5.0.0 ]

--- a/99-integration/dubbo-samples-registry-test-curator-interface/case-versions.conf
+++ b/99-integration/dubbo-samples-registry-test-curator-interface/case-versions.conf
@@ -23,4 +23,4 @@
 dubbo.version=[ >= 3.2.0 ]
 spring.version=4.*, 5.*
 java.version= [ >= 8 ]
-curator.version= [ >= 4.0.0 ]
+curator.version= [ >= 5.0.0 ]

--- a/99-integration/dubbo-samples-registry-test-curator/case-versions.conf
+++ b/99-integration/dubbo-samples-registry-test-curator/case-versions.conf
@@ -23,4 +23,4 @@
 dubbo.version=[ >= 3.2.0 ]
 spring.version=4.*, 5.*
 java.version= [ >= 8 ]
-curator.version= [ >= 4.0.0 ]
+curator.version= [ >= 5.0.0 ]


### PR DESCRIPTION
refer: [#14028](https://github.com/apache/dubbo/pull/14028)
This is a part of PR **feat:Remove zk3.4 support in 3.3**  