### PR TITLE
Updated dubbo version of nightly action to 3.3

### DIFF
--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -23,12 +23,10 @@ env:
   VERSIONS_LIMIT: 12
   #candidate versions (the dubbo snapshot version will be extracted from pom.xml and appended before CANDIDATE_VERSIONS )
   CANDIDATE_VERSIONS: '
-    dubbo.version: 3.0.3;
-    spring.version: 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.20.RELEASE, 5.3.3;
-    spring-boot.version: 1.1.12.RELEASE, 1.2.8.RELEASE, 1.3.8.RELEASE, 1.4.7.RELEASE, 1.5.22.RELEASE;
-    spring-boot.version: 2.0.9.RELEASE, 2.1.18.RELEASE, 2.2.12.RELEASE, 2.3.7.RELEASE, 2.4.1
+    spring.version:5.3.24;
+    spring-boot.version:2.7.6;
     '
-  DUBBO_REF: '3.1'
+  DUBBO_REF: '3.3'
 
 jobs:
   build-samples:


### PR DESCRIPTION
Nightly Dubbo 3 action had been failed for a long time since it's could not run with dubbo 3.1, see https://github.com/apache/dubbo-integration-cases/actions/runs/14000889167/job/39206936214
![failed](https://github.com/user-attachments/assets/2635cd7b-e1d5-442d-8b6f-8df4a0998bb0)
