### PR TITLE
Fix workflow issues by updating dubbo version of pom.xml to 3.3.4 if 3.3 is included in case-versions.conf

### DIFF
--- a/.github/workflows/dubbo-3_2.yml
+++ b/.github/workflows/dubbo-3_2.yml
@@ -173,7 +173,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-${{matrix.java}}-${{matrix.job_id}}
+          name: test-result-${{matrix.job_id}}-java${{matrix.java}}
           path: test/jobs/*-result*
 
   test_result:
@@ -192,7 +192,8 @@ jobs:
       - name: Download test result
         uses: actions/download-artifact@v4
         with:
-          pattern: test-result-*
+          pattern: test-result-*-java${{matrix.java}}
           path: test/jobs/
+          merge-multiple: true
       - name: Merge test result - java ${{matrix.java}}
         run: ./test/scripts/merge-test-results.sh

--- a/.github/workflows/dubbo-3_3.yml
+++ b/.github/workflows/dubbo-3_3.yml
@@ -23,8 +23,8 @@ env:
   VERSIONS_LIMIT: 4
   #candidate versions (the dubbo snapshot version will be extracted from pom.xml and appended before CANDIDATE_VERSIONS )
   CANDIDATE_VERSIONS: '
-    spring.version:5.3.24;
-    spring-boot.version:2.7.6;
+    spring.version:5.3.24,6.1.5;
+    spring-boot.version:2.7.6,3.2.3;
     '
   DUBBO_REF: '3.3'
 
@@ -173,7 +173,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-${{matrix.java}}-${{matrix.job_id}}
+          name: test-result-${{matrix.job_id}}-java${{matrix.java}}
           path: test/jobs/*-result*
 
   test_result:
@@ -192,7 +192,8 @@ jobs:
       - name: Download test result
         uses: actions/download-artifact@v4
         with:
-          pattern: test-result-*
+          pattern: test-result-*-java${{matrix.java}}
           path: test/jobs/
+          merge-multiple: true
       - name: Merge test result - java ${{matrix.java}}
         run: ./test/scripts/merge-test-results.sh

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -23,12 +23,12 @@ env:
   VERSIONS_LIMIT: 12
   #candidate versions (the dubbo snapshot version will be extracted from pom.xml and appended before CANDIDATE_VERSIONS )
   CANDIDATE_VERSIONS: '
-    dubbo.version: 3.0.3;
+    dubbo.version: 3.3.4;
     spring.version: 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.20.RELEASE, 5.3.3;
     spring-boot.version: 1.1.12.RELEASE, 1.2.8.RELEASE, 1.3.8.RELEASE, 1.4.7.RELEASE, 1.5.22.RELEASE;
     spring-boot.version: 2.0.9.RELEASE, 2.1.18.RELEASE, 2.2.12.RELEASE, 2.3.7.RELEASE, 2.4.1
     '
-  DUBBO_REF: '3.1'
+  DUBBO_REF: '3.3'
 
 jobs:
   build-samples:

--- a/.github/workflows/nightly-dubbo-3.yml
+++ b/.github/workflows/nightly-dubbo-3.yml
@@ -23,10 +23,9 @@ env:
   VERSIONS_LIMIT: 12
   #candidate versions (the dubbo snapshot version will be extracted from pom.xml and appended before CANDIDATE_VERSIONS )
   CANDIDATE_VERSIONS: '
-    dubbo.version: 3.3.4;
-    spring.version: 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.20.RELEASE, 5.3.3;
+    spring.version: 4.2.9.RELEASE, 4.3.30.RELEASE, 5.1.20.RELEASE, 5.3.3, 5.3.24, 6.1.5;
     spring-boot.version: 1.1.12.RELEASE, 1.2.8.RELEASE, 1.3.8.RELEASE, 1.4.7.RELEASE, 1.5.22.RELEASE;
-    spring-boot.version: 2.0.9.RELEASE, 2.1.18.RELEASE, 2.2.12.RELEASE, 2.3.7.RELEASE, 2.4.1
+    spring-boot.version: 2.0.9.RELEASE, 2.1.18.RELEASE, 2.2.12.RELEASE, 2.3.7.RELEASE, 2.4.1, 2.7.6, 3.2.3;
     '
   DUBBO_REF: '3.3'
 
@@ -172,7 +171,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-result-${{matrix.java}}-${{matrix.job_id}}
+          name: test-result-${{matrix.job_id}}-java${{matrix.java}}
           path: test/jobs/*-result*
 
   test_result:
@@ -191,7 +190,8 @@ jobs:
       - name: Download test result
         uses: actions/download-artifact@v4
         with:
-          pattern: test-result-*
+          pattern: test-result-*-java${{matrix.java}}
           path: test/jobs/
+          merge-multiple: true
       - name: Merge test result - java ${{matrix.java}}
         run: ./test/scripts/merge-test-results.sh

--- a/99-integration/dubbo-samples-empty-protection-nacos/pom.xml
+++ b/99-integration/dubbo-samples-empty-protection-nacos/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-empty-protection/pom.xml
+++ b/99-integration/dubbo-samples-empty-protection/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-isolation-executor/pom.xml
+++ b/99-integration/dubbo-samples-isolation-executor/pom.xml
@@ -31,7 +31,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.version>4.3.30.RELEASE</spring.version>
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>
 

--- a/99-integration/dubbo-samples-memory-server/pom.xml
+++ b/99-integration/dubbo-samples-memory-server/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <junit5.version>5.9.2</junit5.version>

--- a/99-integration/dubbo-samples-memory-tri-server/pom.xml
+++ b/99-integration/dubbo-samples-memory-tri-server/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.11</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <protobuf-java.version>3.24.3</protobuf-java.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-configcenter/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-annotation/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-properties/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
+++ b/99-integration/dubbo-samples-metadata-report/dubbo-samples-metadata-report-local-xml/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-multi-port/pom.xml
+++ b/99-integration/dubbo-samples-multi-port/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>5.3.25</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-nacos-legacy/case-configuration.yml
+++ b/99-integration/dubbo-samples-nacos-legacy/case-configuration.yml
@@ -16,7 +16,8 @@
 
 services:
   nacos:
-    image: nacos/nacos-server:v2.1.2-slim
+    # set large DB_POOL_CONNECTION_TIMEOUT (provided since nacos-server v2.3.1+) to avoid login timeout.
+    image: nacos/nacos-server:v2.3.1-slim
     environment:
       - PREFER_HOST_MODE=hostname
       - MODE=standalone
@@ -24,6 +25,7 @@ services:
       - JVM_XMS=512m
       - JVM_XMX=512m
       - JVM_XMN=256m
+      - DB_POOL_CONNECTION_TIMEOUT=30000
 
   dubbo-samples-nacos-legacy-provider1:
     type: app

--- a/99-integration/dubbo-samples-nacos-legacy/pom.xml
+++ b/99-integration/dubbo-samples-nacos-legacy/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <junit.version>4.13.1</junit.version>
 

--- a/99-integration/dubbo-samples-nacos-merge/pom.xml
+++ b/99-integration/dubbo-samples-nacos-merge/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-port-unification-netty3/pom.xml
+++ b/99-integration/dubbo-samples-port-unification-netty3/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.version>4.3.30.RELEASE</spring.version>
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-prefer-serialization-test/pom.xml
+++ b/99-integration/dubbo-samples-prefer-serialization-test/pom.xml
@@ -109,6 +109,12 @@
                 <groupId>org.apache.dubbo.extensions</groupId>
                 <artifactId>dubbo-serialization-jdk</artifactId>
                 <version>${dubbo-serialization-gson.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.alibaba</groupId>
+                        <artifactId>hessian-lite</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/99-integration/dubbo-samples-prefer-serialization-test/pom.xml
+++ b/99-integration/dubbo-samples-prefer-serialization-test/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <dubbo-serialization-fastjson.version>1.0.1</dubbo-serialization-fastjson.version>
         <dubbo-serialization-gson.version>3.3.0</dubbo-serialization-gson.version>
         <dubbo-serialization-fst.version>1.0.1</dubbo-serialization-fst.version>

--- a/99-integration/dubbo-samples-registry-test-curator-instance/pom.xml
+++ b/99-integration/dubbo-samples-registry-test-curator-instance/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <zookeeper.version>3.8.4</zookeeper.version>
         <curator.version>5.1.0</curator.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/99-integration/dubbo-samples-registry-test-curator-interface/pom.xml
+++ b/99-integration/dubbo-samples-registry-test-curator-interface/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <zookeeper.version>3.8.4</zookeeper.version>
         <curator.version>5.1.0</curator.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/99-integration/dubbo-samples-registry-test-curator/pom.xml
+++ b/99-integration/dubbo-samples-registry-test-curator/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <zookeeper.version>3.8.4</zookeeper.version>
         <curator.version>5.1.0</curator.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/99-integration/dubbo-samples-registry-test-nacos-instance/pom.xml
+++ b/99-integration/dubbo-samples-registry-test-nacos-instance/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <nacos.version>2.2.0</nacos.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-registry-test-nacos-interface/pom.xml
+++ b/99-integration/dubbo-samples-registry-test-nacos-interface/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <nacos.version>2.2.0</nacos.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-registry-test-nacos/pom.xml
+++ b/99-integration/dubbo-samples-registry-test-nacos/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <nacos.version>2.1.1</nacos.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-router-chain-switch/pom.xml
+++ b/99-integration/dubbo-samples-router-chain-switch/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.version>4.3.30.RELEASE</spring.version>
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-sd-group/pom.xml
+++ b/99-integration/dubbo-samples-sd-group/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-sd-merge/pom.xml
+++ b/99-integration/dubbo-samples-sd-merge/pom.xml
@@ -47,7 +47,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-sd-version/pom.xml
+++ b/99-integration/dubbo-samples-sd-version/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-sentinel-compact/pom.xml
+++ b/99-integration/dubbo-samples-sentinel-compact/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <sentinel.version>1.8.4</sentinel.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/99-integration/dubbo-samples-sentinel-dubbo3/pom.xml
+++ b/99-integration/dubbo-samples-sentinel-dubbo3/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <sentinel.version>1.8.6</sentinel.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/99-integration/dubbo-samples-serialize-check/pom.xml
+++ b/99-integration/dubbo-samples-serialize-check/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <awaitility.version>4.2.0</awaitility.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-switch-serialization-thread/pom.xml
+++ b/99-integration/dubbo-samples-switch-serialization-thread/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-10704/pom.xml
+++ b/99-integration/dubbo-samples-test-10704/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>5.3.25</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>

--- a/99-integration/dubbo-samples-test-11096/pom.xml
+++ b/99-integration/dubbo-samples-test-11096/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-11137/pom.xml
+++ b/99-integration/dubbo-samples-test-11137/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-11159/pom.xml
+++ b/99-integration/dubbo-samples-test-11159/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-11557/pom.xml
+++ b/99-integration/dubbo-samples-test-11557/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
     </properties>

--- a/99-integration/dubbo-samples-test-11558/pom.xml
+++ b/99-integration/dubbo-samples-test-11558/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
     </properties>

--- a/99-integration/dubbo-samples-test-11716/pom.xml
+++ b/99-integration/dubbo-samples-test-11716/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
     </properties>

--- a/99-integration/dubbo-samples-test-11782/pom.xml
+++ b/99-integration/dubbo-samples-test-11782/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/99-integration/dubbo-samples-test-12208/pom.xml
+++ b/99-integration/dubbo-samples-test-12208/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <junit5.version>5.9.2</junit5.version>
 

--- a/99-integration/dubbo-samples-test-12376/pom.xml
+++ b/99-integration/dubbo-samples-test-12376/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/99-integration/dubbo-samples-test-12631/pom.xml
+++ b/99-integration/dubbo-samples-test-12631/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/99-integration/dubbo-samples-test-12697/pom.xml
+++ b/99-integration/dubbo-samples-test-12697/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-13078/pom.xml
+++ b/99-integration/dubbo-samples-test-13078/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test for 13078</description>
 
     <properties>
-        <dubbo.version>3.2.8</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-13133/case-versions.conf
+++ b/99-integration/dubbo-samples-test-13133/case-versions.conf
@@ -21,5 +21,5 @@
 
 # Spring app
 dubbo.version=2.7*, 3.*
-spring.version=4.*, 5.*, 6.*
+spring.version=4.*, 5.*
 java.version= [>= 8]

--- a/99-integration/dubbo-samples-test-13133/pom.xml
+++ b/99-integration/dubbo-samples-test-13133/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>5.3.25</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-13224/pom.xml
+++ b/99-integration/dubbo-samples-test-13224/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test for 13078</description>
 
     <properties>
-        <dubbo.version>3.2.8</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-13360-33x/pom.xml
+++ b/99-integration/dubbo-samples-test-13360-33x/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test for 13360 On Dubbo 3.3.x</description>
 
     <properties>
-        <dubbo.version>3.3.0-beta.1</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-13436-1/pom.xml
+++ b/99-integration/dubbo-samples-test-13436-1/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.9</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-test-13436-2/pom.xml
+++ b/99-integration/dubbo-samples-test-13436-2/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.9</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-test-13436-3/pom.xml
+++ b/99-integration/dubbo-samples-test-13436-3/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.9</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-test-13436-4/pom.xml
+++ b/99-integration/dubbo-samples-test-13436-4/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.9</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-test-13441-1/pom.xml
+++ b/99-integration/dubbo-samples-test-13441-1/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.9</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-test-13441-2/pom.xml
+++ b/99-integration/dubbo-samples-test-13441-2/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.9</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
 
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>

--- a/99-integration/dubbo-samples-test-13441-3/pom.xml
+++ b/99-integration/dubbo-samples-test-13441-3/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.10</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <gson_version>2.10.1</gson_version>
 

--- a/99-integration/dubbo-samples-test-13441-4/pom.xml
+++ b/99-integration/dubbo-samples-test-13441-4/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.10</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <gson_version>2.10.1</gson_version>
 

--- a/99-integration/dubbo-samples-test-13441-5/pom.xml
+++ b/99-integration/dubbo-samples-test-13441-5/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.10</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <gson_version>2.10.1</gson_version>
 

--- a/99-integration/dubbo-samples-test-13441-6/pom.xml
+++ b/99-integration/dubbo-samples-test-13441-6/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.10</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <gson_version>2.10.1</gson_version>
 

--- a/99-integration/dubbo-samples-test-13441-7/pom.xml
+++ b/99-integration/dubbo-samples-test-13441-7/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.10</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <gson_version>2.10.1</gson_version>
 

--- a/99-integration/dubbo-samples-test-13560/pom.xml
+++ b/99-integration/dubbo-samples-test-13560/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test for 13560</description>
 
     <properties>
-        <dubbo.version>3.2.11</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-13580/pom.xml
+++ b/99-integration/dubbo-samples-test-13580/pom.xml
@@ -36,7 +36,7 @@
     <description>Dubbo Samples Test for 13580</description>
 
     <properties>
-        <dubbo.version>3.2.10</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit5.version>5.9.2</junit5.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-13751/pom.xml
+++ b/99-integration/dubbo-samples-test-13751/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.11</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <protobuf-java.version>3.24.4</protobuf-java.version>
 

--- a/99-integration/dubbo-samples-test-13787/pom.xml
+++ b/99-integration/dubbo-samples-test-13787/pom.xml
@@ -34,7 +34,7 @@
     <artifactId>dubbo-samples-test-13787</artifactId>
 
     <properties>
-        <dubbo.version>3.2.11</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <junit.version>4.13.1</junit.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/99-integration/dubbo-samples-test-9806/pom.xml
+++ b/99-integration/dubbo-samples-test-9806/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-abc-async/case-versions.conf
+++ b/99-integration/dubbo-samples-test-abc-async/case-versions.conf
@@ -21,5 +21,5 @@
 
 # Spring app
 dubbo.version=2.7*, 3.*
-spring.version=4.*, 5.*, 6.*
+spring.version=4.*, 5.*
 java.version= [>= 8]

--- a/99-integration/dubbo-samples-test-abc-async/pom.xml
+++ b/99-integration/dubbo-samples-test-abc-async/pom.xml
@@ -38,7 +38,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <spring.version>5.3.25</spring.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit.version>4.13.1</junit.version>

--- a/99-integration/dubbo-samples-test-register-3-3/pom.xml
+++ b/99-integration/dubbo-samples-test-register-3-3/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.3.0-beta.1</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/99-integration/dubbo-samples-test-register/pom.xml
+++ b/99-integration/dubbo-samples-test-register/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/99-integration/dubbo-samples-test-register/pom.xml
+++ b/99-integration/dubbo-samples-test-register/pom.xml
@@ -40,7 +40,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.3.4</dubbo.version>
+        <dubbo.version>3.2.6</dubbo.version>
         <log4j2.version>2.20.0</log4j2.version>
         <junit5.version>5.9.2</junit5.version>
         <awaitility.version>4.2.0</awaitility.version>

--- a/99-integration/dubbo-samples-transaction/pom.xml
+++ b/99-integration/dubbo-samples-transaction/pom.xml
@@ -39,7 +39,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dubbo.version>3.2.6</dubbo.version>
+        <dubbo.version>3.3.4</dubbo.version>
         <seata.version>1.4.2</seata.version>
         <spring.version>4.3.30.RELEASE</spring.version>
         <log4j2.version>2.20.0</log4j2.version>

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -25,7 +25,7 @@ echo "FORK_COUNT: $maxForks"
 export DEBUG=$DEBUG
 echo "DEBUG=$DEBUG"
 
-DUBBO_VERSION=${DUBBO_VERSION:-3.2.6}
+DUBBO_VERSION=${DUBBO_VERSION:-3.3.4}
 if [ "$CANDIDATE_VERSIONS" == "" ];then
   CANDIDATE_VERSIONS="dubbo.version:$DUBBO_VERSION;spring.version:5.3.30;spring-boot.version:1.5.13.RELEASE,2.7.16"
 #  CANDIDATE_VERSIONS="dubbo.version:2.7.12;spring.version:4.3.16.RELEASE,5.3.3;spring-boot.version:1.5.13.RELEASE,2.1.1.RELEASE"


### PR DESCRIPTION
Fix workflow issues:
![image](https://github.com/user-attachments/assets/322bd58a-30b7-4de1-95f0-03c1550a72fd)

1. Update dubbo version of pom.xml to 3.3.4 if 3.3 is included in case-versions.conf
2. Remove spring6 from the candidate versions of dubbo-samples-test-abc-async,dubbo-samples-test-13133 because of incompatibility when runing them with jdk8 or jdk11.
see details at https://github.com/apache/dubbo-integration-cases/actions/runs/15382936213/job/43276601668  https://github.com/apache/dubbo-integration-cases/actions/runs/15382936213/job/43276601967
```
Error:    bad class file: /home/runner/.m2/repository/org/springframework/spring-context/6.1.5/spring-context-6.1.5.jar(org/springframework/context/support/ClassPathXmlApplicationContext.class)
Error:      class file has wrong version 61.0, should be 52.0
```
3. Set large ```DB_POOL_CONNECTION_TIMEOUT``` environment with nacos-server 2.3.1 of dubbo-samples-nacos-legacy to avoid db login timeout.
see details at https://github.com/apache/dubbo/actions/runs/15399465385/job/43329027034
```
Caused by: org.apache.derby.iapi.error.StandardException: Login timeout exceeded.
```
4. Fix test results download step of dubbo workflows by setting ```merge-multiple``` true to extract test result files from the download zip files for merging correctly.
5. Exclude ```com.alibaba/hessian-lite``` to avoid conflict with ```org.apache.dubbo/hessian-lite```, otherwise the result of dubbo ```Build and Test Scheduled On 3.3``` might fail since the latest dubbo (3.3.4) is incompatible with ```com.alibaba/hessian-lite```, see detail at https://github.com/apache/dubbo/actions/runs/15263954530/job/42926652437
```
2025-05-27T00:42:19.7068804Z java.lang.NoSuchMethodError: 'boolean org.apache.dubbo.common.serialize.hessian2.Hessian2SerializerFactory.isEnableUnsafeSerializer()'
2025-05-27T00:42:19.7070933Z 	at org.apache.dubbo.common.serialize.hessian2.Hessian2SerializerFactory.getDefaultSerializer(Hessian2SerializerFactory.java:63) ~[dubbo-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
2025-05-27T00:42:19.7072857Z 	at com.alibaba.com.caucho.hessian.io.SerializerFactory.getSerializer(SerializerFactory.java:393) ~[hessian-lite-3.2.13.jar:?]
2025-05-27T00:42:19.7074312Z 	at com.alibaba.com.caucho.hessian.io.Hessian2Output.writeObject(Hessian2Output.java:411) ~[hessian-lite-3.2.13.jar:?]  <=== call com.alibaba/hessian-lite-3.2.13.jar because it is prior to org.apache.dubbo/hessian-lite-4.0.3.jar at class.path
2025-05-27T00:42:19.7077272Z 	at org.apache.dubbo.common.serialize.hessian2.Hessian2ObjectOutput.writeObject(Hessian2ObjectOutput.java:102) ~[dubbo-3.3.4-SNAPSHOT.jar:3.3.4-SNAPSHOT]
```
java.class.path:
```
java.class.path=/usr/local/dubbo/app/classes:/usr/local/dubbo/app/dependency/curator-client-5.8.0.jar:/usr/local/dubbo/app/dependency/netty-transport-native-epoll-4.2.1.Final-linux-aarch_64.jar:/usr/local/dubbo/app/dependency/objenesis-2.4.jar:/usr/local/dubbo/app/dependency/netty-codec-marshalling-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/dubbo-serialization-fastjson-1.0.1.jar:/usr/local/dubbo/app/dependency/netty-codec-classes-quic-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-classes-kqueue-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-codec-smtp-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/zookeeper-3.7.2.jar:/usr/local/dubbo/app/dependency/netty-codec-native-quic-4.2.1.Final-osx-aarch_64.jar:/usr/local/dubbo/app/dependency/netty-resolver-dns-native-macos-4.2.1.Final-osx-x86_64.jar:/usr/local/dubbo/app/dependency/netty-resolver-dns-native-macos-4.2.1.Final-osx-aarch_64.jar:/usr/local/dubbo/app/dependency/dubbo-serialization-fst-1.0.1.jar:/usr/local/dubbo/app/dependency/netty-codec-protobuf-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/curator-x-discovery-5.8.0.jar:/usr/local/dubbo/app/dependency/netty-transport-classes-io_uring-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-rxtx-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/jackson-core-2.19.0.jar:/usr/local/dubbo/app/dependency/netty-resolver-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-codec-stomp-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-native-unix-common-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/dubbo-serialization-gson-3.3.0.jar:/usr/local/dubbo/app/dependency/netty-codec-http-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/hamcrest-2.2.jar:/usr/local/dubbo/app/dependency/netty-codec-native-quic-4.2.1.Final-windows-x86_64.jar:/usr/local/dubbo/app/dependency/netty-codec-dns-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/log4j-api-2.24.3.jar:/usr/local/dubbo/app/dependency/junit-4.13.1.jar:/usr/local/dubbo/app/dependency/netty-transport-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/slf4j-api-1.7.36.jar:
/usr/local/dubbo/app/dependency/hessian-lite-3.2.13.jar:   <=====  this is com.alibaba/hessian-lite !!!
/usr/local/dubbo/app/dependency/checker-qual-3.33.0.jar:/usr/local/dubbo/app/dependency/netty-codec-native-quic-4.2.1.Final-osx-x86_64.jar:/usr/local/dubbo/app/dependency/netty-codec-memcache-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/javax.annotation-api-1.3.2.jar:/usr/local/dubbo/app/dependency/netty-common-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-native-io_uring-4.2.1.Final-linux-aarch_64.jar:/usr/local/dubbo/app/dependency/java-util-1.9.0.jar:/usr/local/dubbo/app/dependency/netty-handler-ssl-ocsp-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/jackson-databind-2.19.0.jar:/usr/local/dubbo/app/dependency/dubbo-samples-prefer-serialization-test-api-1.0-SNAPSHOT.jar:/usr/local/dubbo/app/dependency/netty-transport-native-kqueue-4.2.1.Final-osx-aarch_64.jar:/usr/local/dubbo/app/dependency/netty-transport-native-kqueue-4.2.1.Final-osx-x86_64.jar:/usr/local/dubbo/app/dependency/netty-codec-http2-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-resolver-dns-classes-macos-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-native-epoll-4.2.1.Final-linux-x86_64.jar:/usr/local/dubbo/app/dependency/gson-2.13.1.jar:/usr/local/dubbo/app/dependency/netty-resolver-dns-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/fst-2.48-jdk-6.jar:/usr/local/dubbo/app/dependency/netty-codec-compression-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/fastjson-1.2.83_noneautotype.jar:/usr/local/dubbo/app/dependency/jsr305-3.0.2.jar:/usr/local/dubbo/app/dependency/spring-test-5.3.24.jar:/usr/local/dubbo/app/dependency/dubbo-serialization-common-3.3.0.jar:/usr/local/dubbo/app/dependency/curator-framework-5.8.0.jar:/usr/local/dubbo/app/dependency/netty-codec-base-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/protobuf-java-3.25.7.jar:/usr/local/dubbo/app/dependency/error_prone_annotations-2.38.0.jar:/usr/local/dubbo/app/dependency/netty-codec-native-quic-4.2.1.Final-linux-x86_64.jar:/usr/local/dubbo/app/dependency/dubbo-serialization-jdk-3.3.0.jar:/usr/local/dubbo/app/dependency/netty-buffer-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-handler-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-sctp-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/failureaccess-1.0.1.jar:/usr/local/dubbo/app/dependency/commons-logging-1.3.5.jar:/usr/local/dubbo/app/dependency/log4j-core-2.24.3.jar:/usr/local/dubbo/app/dependency/netty-codec-haproxy-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-udt-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-codec-mqtt-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/usr/local/dubbo/app/dependency/snakeyaml-2.4.jar:/usr/local/dubbo/app/dependency/netty-codec-xml-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/guava-32.0.0-jre.jar:/usr/local/dubbo/app/dependency/spring-core-5.3.24.jar:/usr/local/dubbo/app/dependency/netty-transport-native-epoll-4.2.1.Final-linux-riscv64.jar:/usr/local/dubbo/app/dependency/log4j-slf4j-impl-2.20.0.jar:/usr/local/dubbo/app/dependency/zookeeper-jute-3.7.2.jar:/usr/local/dubbo/app/dependency/netty-all-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-codec-native-quic-4.2.1.Final-linux-aarch_64.jar:/usr/local/dubbo/app/dependency/javassist-3.30.2-GA.jar:/usr/local/dubbo/app/dependency/dubbo-3.3.4-SNAPSHOT.jar:/usr/local/dubbo/app/dependency/netty-transport-native-io_uring-4.2.1.Final-linux-riscv64.jar:
/usr/local/dubbo/app/dependency/hessian-lite-4.0.3.jar: <====== this is org.apache.dubbo/hessian-lite
/usr/local/dubbo/app/dependency/curator-recipes-5.8.0.jar:/usr/local/dubbo/app/dependency/netty-transport-native-io_uring-4.2.1.Final-linux-x86_64.jar:/usr/local/dubbo/app/dependency/netty-codec-socks-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/dubbo-zookeeper-curator5-spring-boot-starter-3.3.4-SNAPSHOT.jar:/usr/local/dubbo/app/dependency/j2objc-annotations-2.8.jar:/usr/local/dubbo/app/dependency/jackson-annotations-2.19.0.jar:/usr/local/dubbo/app/dependency/netty-handler-proxy-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/hamcrest-core-2.2.jar:/usr/local/dubbo/app/dependency/spring-jcl-5.3.24.jar:/usr/local/dubbo/app/dependency/netty-codec-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-transport-classes-epoll-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/netty-codec-redis-4.2.1.Final.jar:/usr/local/dubbo/app/dependency/json-io-2.5.1.jar:/usr/local/dubbo/app/dependency/fastjson2-2.0.56.jar
```