### PR TITLE
Add failure message to the average response time assertion of dubbo-samples-test-13580

### DIFF
--- a/99-integration/dubbo-samples-test-13580/src/test/java/org/apache/dubbo/samples/client/GreetingServiceIT.java
+++ b/99-integration/dubbo-samples-test-13580/src/test/java/org/apache/dubbo/samples/client/GreetingServiceIT.java
@@ -82,7 +82,8 @@ public class GreetingServiceIT {
                     }
                 }
             }
-            Assertions.assertEquals(2, data.size());
+            // TODO sometimes there are no dubbo_consumer_rt_milliseconds_avg in the result.
+            Assertions.assertEquals(2, data.size(), "FAIL result: " + result);
             Assertions.assertTrue(Double.parseDouble(data.get("echo1")) > 0);
             Assertions.assertTrue(Double.parseDouble(data.get("echo2")) > 0);
         }

--- a/99-integration/dubbo-samples-test-13580/src/test/resources/META-INF/services/org.apache.dubbo.common.serialize.Serialization
+++ b/99-integration/dubbo-samples-test-13580/src/test/resources/META-INF/services/org.apache.dubbo.common.serialize.Serialization
@@ -1,1 +1,0 @@
-set=org.apache.dubbo.samples.provider.SerializationSetWrapper


### PR DESCRIPTION
add  failure message to the assertion for future analysis as sometimes there are no dubbo_consumer_rt_milliseconds_avg in the result，
```
String result = HttpUtil.get("http://127.0.0.1:22333/metrics");
```