### PR TITLE
Prolong reference check time of dubbo-samples-test-13078 to avoid no provider issue

### DIFF
--- a/99-integration/dubbo-samples-test-13078/src/test/java/org/apache/dubbo/samples/client/GreetingServiceIT.java
+++ b/99-integration/dubbo-samples-test-13078/src/test/java/org/apache/dubbo/samples/client/GreetingServiceIT.java
@@ -69,9 +69,10 @@ public class GreetingServiceIT {
         await().atMost(60, TimeUnit.SECONDS).untilAsserted(
                 () -> Assertions.assertEquals(2, endpoints.size()));
 
-        // wait invoker re-valid to avoid RpcException with no provider available.
+        // By default, connectivityExecutor delays 1s to set invoker re-valid,
+        // so wait at most 2s to avoid RpcException with no provider available.
         try {
-            reference.checkOrDestroy(1000);
+            reference.checkOrDestroy(2000);
         } catch (IllegalStateException e) {
             Assertions.fail();
         }


### PR DESCRIPTION
the reference check time needs to exceed 1s, because the default value of reconnectTaskPeriod is 1000 which means connectivityExecutor might wait 1s to recover the invoker from invalid list, otherwise reference checking might get failure result just like this:
```
18:21:41.131 |-INFO  [NettyClientWorker-4-2] .transport.netty4.NettyConnectionHandler:95  -|  [DUBBO] The connection [id: 0xbb84b379, L:/172.18.0.4:34928 - R:/172.18.0.3:50051] of 172.18.0.4:34928 -> 172.18.0.3:50051 is established., dubbo version: 3.3.6-SNAPSHOT, current host: 172.18.0.4
18:21:42.124 |-WARN  [main]  org.apache.dubbo.config.ReferenceConfig:    -|  [DUBBO] Check reference of [org.apache.dubbo.samples.api.GreetingsService] failed very beginning. After 1002ms reties, finally failed., dubbo version: 3.3.6-SNAPSHOT, current host: 172.18.0.4, error code: 1-4. This may be caused by , go to https://dubbo.apache.org/faq/1/4 to find instructions. 
18:21:42.127 |-INFO  [Dubbo-framework-connectivity-scheduler-thread-2] .rpc.cluster.directory.AbstractDirectory:369 -|  [DUBBO] Recover service address: tri://172.18.0.3:50051/org.apache.dubbo.samples.api.GreetingsService?application=first-dubbo-provider&background=false&category=providers,configurators,routers&check=false&deprecated=false&dubbo=2.0.2&dynamic=true&environment=product&executor-management-mode=isolation&file-cache=true&generic=false&interface=org.apache.dubbo.samples.api.GreetingsService&methods=sayHi&pid=17&prefer.serialization=hessian2,fastjson2&release=3.3.6-SNAPSHOT&service-name-mapping=true&side=provider&sticky=false&unloadClusterRelated=false  from invalid list., dubbo version: 3.3.6-SNAPSHOT, current host: 172.18.0.4
```

schedule connectivityExecutor at AbstractDirectory.java
```
public void checkConnectivity() {
        // try to submit task, to ensure there is only one task at most for each directory
        if (checkConnectivityPermit.tryAcquire()) {
            this.connectivityCheckFuture = connectivityExecutor.schedule(
                    ... ... ...
                    },
                    reconnectTaskPeriod,  // DEFAULT_RECONNECT_TASK_PERIOD = 1000
                    TimeUnit.MILLISECONDS);
        }
```
