### PR TITLE
Set default local reserved ports for tests

### DIFF
--- a/test/dubbo-scenario-builder/src/main/resources/docker-compose.template
+++ b/test/dubbo-scenario-builder/src/main/resources/docker-compose.template
@@ -96,4 +96,6 @@ services:
             - ${item}
         </#list>
         </#if>
+        sysctls:
+          net.ipv4.ip_local_reserved_ports: 50050-50059
 </#list>

--- a/test/dubbo-test-runner/src/docker/run.sh
+++ b/test/dubbo-test-runner/src/docker/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 echo "Start at: $(date "+%Y-%m-%d %H:%M:%S")"
+echo "Current "`sysctl net.ipv4.ip_local_reserved_ports`
 
 DIR=/usr/local/dubbo
 cd $DIR


### PR DESCRIPTION
50050,50051 ports fall within Linux's default ephemeral port range (32768–61000). According to port classification standards, these ports belong to the dynamic/private port range (49152–65535) and are typically used for temporary connection assignments in client programs, they should be reserved to avoid address already in used exception during testing.