### PR TITLE
Upgrade jacoco to 0.8.13 for supporting JDK 23 and 24 class files

### DIFF
--- a/test/dubbo-scenario-builder/src/main/java/org/apache/dubbo/scenario/builder/JacocoDownloader.java
+++ b/test/dubbo-scenario-builder/src/main/java/org/apache/dubbo/scenario/builder/JacocoDownloader.java
@@ -40,9 +40,9 @@ public class JacocoDownloader {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /**
-     * The jacoco agent version
+     * The jacoco agent version, set to 0.8.13 for supporting JDK 23 and 24 class files
      */
-    private static final String JACOCO_VERSION = "0.8.8";
+    private static final String JACOCO_VERSION = "0.8.13";
 
     /**
      * The jacoco binary file name


### PR DESCRIPTION
Jacoco 0.8.8 does not support JDK 21+ class files,
```
Caused by: java.io.IOException: Error while instrumenting org/apache/dubbo/common/threadpool/support/loom/VirtualThreadPool with JaCoCo 0.8.8.202204050719/5dcf34a.
	at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrumentError(Instrumenter.java:161)
	at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrument(Instrumenter.java:111)
	at org.jacoco.agent.rt.internal_b6258fc.CoverageTransformer.transform(CoverageTransformer.java:92)
	... 176 more
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 65
	at org.jacoco.agent.rt.internal_b6258fc.asm.ClassReader.<init>(ClassReader.java:199)
	at org.jacoco.agent.rt.internal_b6258fc.asm.ClassReader.<init>(ClassReader.java:180)
	at org.jacoco.agent.rt.internal_b6258fc.asm.ClassReader.<init>(ClassReader.java:166)
	at org.jacoco.agent.rt.internal_b6258fc.core.internal.instr.InstrSupport.classReaderFor(InstrSupport.java:280)
	at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrument(Instrumenter.java:77)
	at org.jacoco.agent.rt.internal_b6258fc.core.instr.Instrumenter.instrument(Instrumenter.java:109)
```