### PR TITLE
Prolong mergeService reference timeout from default 1s to 3s for slowly running system

### DIFF
--- a/99-integration/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-consumer/src/main/resources/spring/merge-consumer.xml
+++ b/99-integration/dubbo-samples-nacos-merge/dubbo-samples-nacos-merge-consumer/src/main/resources/spring/merge-consumer.xml
@@ -28,6 +28,6 @@
     <dubbo:registry address="nacos://${nacos.address:127.0.0.1}:8848?username=nacos&amp;password=nacos"/>
 
     <dubbo:reference id="mergeService" interface="org.apache.dubbo.samples.merge.api.MergeService" group="*"
-                     merger="true"/>
+                     merger="true" timeout="3000" />
 
 </beans>


### PR DESCRIPTION
The version of Ubuntu which github actions used was upgraded from 20251216.185.1 to  20260105.207.1 since https://github.com/apache/dubbo/actions/runs/20836705809,
<img width="1750" height="765" alt="086b8ee75b9eba3ed42651919a6f2a3c" src="https://github.com/user-attachments/assets/6a1c5809-b4a7-4ef6-a03d-9f8aa3a72fc4" />

```dubbo-samples-nacos-merge``` began to fail from that point onward, the cause might be the invocation will take more times under new Ubuntu version,
<img width="1350" height="341" alt="image" src="https://github.com/user-attachments/assets/aa7da4c8-381a-452b-a35c-a3c98a9f2c0a" />

